### PR TITLE
adds two key/value pairs to demonstrate devOps

### DIFF
--- a/server-manifest-values.yaml
+++ b/server-manifest-values.yaml
@@ -1,2 +1,4 @@
 atlas_uri: <+secrets.getValue("atlas_uri")>
 server_image: <+artifact.image>
+deployment_replicas: 1
+container_port: 5001

--- a/server-manifest.yaml
+++ b/server-manifest.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     version: v1
 spec:
-  replicas: 1
+  replicas: {{.Values.deployment_replicas}}
   selector:
     matchLabels:
       app: server
@@ -42,4 +42,4 @@ spec:
             cpu: "100m"
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 5001
+        - containerPort: {{.Values.container_port}}


### PR DESCRIPTION
Modifies the server manifest and values-manifests to include two variables that are hard-coded in the values.